### PR TITLE
SimpleView polyfill refactor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,21 @@
             "preLaunchTask": "npm: build"
         },
         {
+          "name": "Launch Extension (Development mode)",
+          "type": "extensionHost",
+          "request": "launch",
+          "runtimeExecutable": "${execPath}",
+          "args": [
+              "--extensionDevelopmentPath=${workspaceFolder}"
+          ],
+          "stopOnEntry": false,
+          "sourceMaps": true,
+          "outFiles": [
+              "${workspaceFolder}/out/**/*.js"
+          ],
+          "preLaunchTask": "npm: build-debug"
+        },
+        {
             "name": "Launch Tests",
             "type": "node",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -403,6 +403,7 @@
         "package": "vsce package --out network-edge-devtools.vsix",
         "vscode:prepublish": "npm run build-and-lint",
         "build": "npm run build-wp && npm run build-post",
+        "build-debug": "npm run build-wp && ts-node postBuildStep.ts debug",
         "build-wp": "webpack",
         "build-post": "ts-node postBuildStep.ts",
         "build-watch": "npm run build && npm run watch",

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -20,8 +20,6 @@ async function copyFile(srcDir: string, outDir: string, name: string) {
 }
 
 async function copyStaticFiles(debugMode: boolean) {
-    // Copy the static html file to the out directory
-
     // Copy the static css file to the out directory
     const commonSrcDir = "./src/common/";
     const commonOutDir = "./out/common/";

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -3,72 +3,30 @@
 import { getTextFromFile } from "../../test/helpers";
 
 describe("simpleView", () => {
-    it("revealInVSCode calls openInEditor", async () => {
+    it("applyDrawerTabLocationPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const expected = {
-            columnNumber: 0,
-            lineNumber: 0,
-            omitFocus: false,
-            uiSourceCode: {
-                _url: "http://bing.com",
-            },
-        };
-        const mockOpen = jest.fn();
-        (global as any).InspectorFrontendHost = {
-            openInEditor: mockOpen,
-        };
 
-        await apply.revealInVSCode(expected, expected.omitFocus);
-
-        expect(mockOpen).toHaveBeenCalled();
-    });
-
-    // it("applyCommonRevealerPatch correctly changes text", async () => {
-    //     const comparableText =  "Common.Revealer.reveal = function(revealable, omitFocus) { // code";
-    //     let fileContents = getTextFromFile("common/Revealer.js");
-
-    //     // The file was not found, so test that at least the text is being replaced.
-    //     fileContents = fileContents ? fileContents : comparableText;
-    //     const apply = await import("./simpleView");
-    //     const result = apply.applyCommonRevealerPatch(fileContents);
-    //     expect(result).not.toEqual(null);
-    //     expect(result).toEqual(
-    //         expect.stringContaining("Common.Revealer.reveal = function revealInVSCode(revealable, omitFocus) {"));
-    // });
-
-    it("applyInspectorViewPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        // const result = apply.applyInspectorViewPatch(
-        //     "handleAction(context, actionId) { // code");
-        // expect(result).toEqual("handleAction(context, actionId) { return false; // code");
-
-        // const result2 = apply.applyInspectorViewPatch(
-        //     "handleAction(context,actionId) { // code");
-        // expect(result2).toEqual("handleAction(context, actionId) { return false; // code");
-
-        const comparableText3 = "this._showDrawer.bind(this, false), 'drawer-view', true, true // code";
-        let fileContents3 = getTextFromFile("ui/ui.js");
+        const comparableText = "this._showDrawer.bind(this, false), 'drawer-view', true, true // code";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
-        fileContents3 = fileContents3 ? fileContents3 : comparableText3;
-        const result3 = apply.applyDrawerTabLocationPatch(fileContents3);
-        expect(result3).not.toEqual(null);
-        expect(result3).toEqual(
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyDrawerTabLocationPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(
             "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls' // code");
-
-        const comparableText4 = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel') // code";
-        let fileContents4 = getTextFromFile("ui/ui.js");
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents4 = fileContents4 ? fileContents4 : comparableText4;
-        const result4 = apply.applyMainTabTabLocationPatch(fileContents4);
-        expect(result4).not.toEqual(null);
-        expect(result4).toEqual("InspectorFrontendHostInstance), 'panel', true, true, 'network' // code");
     });
 
-    // it("applyMainViewPatch correctly changes text", async () => {
-    //     const apply = await import("./simpleView");
-    //     const result = apply.applyMainViewPatch("const moreTools = getExtensions();");
-    //     expect(result).toEqual("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
-    // });
+    it("applyMainTabTabLocationPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+
+        const comparableText = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel') // code";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyMainTabTabLocationPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual("InspectorFrontendHostInstance), 'panel', true, true, 'network' // code");
+    });
 
     it("applySelectTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
@@ -79,13 +37,6 @@ describe("simpleView", () => {
         const result = apply.applySelectTabPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
-
-        const comparableText2 = "selectTab(id,userGesture, forceFocus) { // code";
-        let fileContents2 = getTextFromFile("ui/TabbedPane.js");
-        fileContents2 = fileContents2 ? fileContents2 : comparableText2;
-        const result2 = apply.applySelectTabPatch(fileContents2);
-        expect(result2).not.toEqual(null);
-        expect(result2).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
     });
 
     it("applyShowTabElementPatch correctly changes text", async () => {

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getTextFromFile } from "../../test/helpers";
 
 describe("simpleView", () => {
     it("revealInVSCode calls openInEditor", async () => {
@@ -22,69 +23,106 @@ describe("simpleView", () => {
         expect(mockOpen).toHaveBeenCalled();
     });
 
-    it("applyCommonRevealerPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        const result = apply.applyCommonRevealerPatch(
-            "Common.Revealer.reveal = function(revealable, omitFocus) { // code");
-        expect(result).toEqual(
-            expect.stringContaining("Common.Revealer.reveal = function revealInVSCode(revealable, omitFocus) {"));
-    });
+    // it("applyCommonRevealerPatch correctly changes text", async () => {
+    //     const comparableText =  "Common.Revealer.reveal = function(revealable, omitFocus) { // code";
+    //     let fileContents = getTextFromFile("common/Revealer.js");
+
+    //     // The file was not found, so test that at least the text is being replaced.
+    //     fileContents = fileContents ? fileContents : comparableText;
+    //     const apply = await import("./simpleView");
+    //     const result = apply.applyCommonRevealerPatch(fileContents);
+    //     expect(result).not.toEqual(null);
+    //     expect(result).toEqual(
+    //         expect.stringContaining("Common.Revealer.reveal = function revealInVSCode(revealable, omitFocus) {"));
+    // });
 
     it("applyInspectorViewPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorViewPatch(
-            "handleAction(context, actionId) { // code");
-        expect(result).toEqual("handleAction(context, actionId) { return false; // code");
+        // const result = apply.applyInspectorViewPatch(
+        //     "handleAction(context, actionId) { // code");
+        // expect(result).toEqual("handleAction(context, actionId) { return false; // code");
 
-        const result2 = apply.applyInspectorViewPatch(
-            "handleAction(context,actionId) { // code");
-        expect(result2).toEqual("handleAction(context, actionId) { return false; // code");
+        // const result2 = apply.applyInspectorViewPatch(
+        //     "handleAction(context,actionId) { // code");
+        // expect(result2).toEqual("handleAction(context, actionId) { return false; // code");
 
-        const result3 = apply.applyDrawerTabLocationPatch(
-            "this._showDrawer.bind(this, false), 'drawer-view', true, true // code");
+        const comparableText3 = "this._showDrawer.bind(this, false), 'drawer-view', true, true // code";
+        let fileContents3 = getTextFromFile("ui/ui.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents3 = fileContents3 ? fileContents3 : comparableText3;
+        const result3 = apply.applyDrawerTabLocationPatch(fileContents3);
+        expect(result3).not.toEqual(null);
         expect(result3).toEqual(
             "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls' // code");
 
-        const result4 = apply.applyMainTabTabLocationPatch(
-            "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel') // code");
+        const comparableText4 = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel') // code";
+        let fileContents4 = getTextFromFile("ui/ui.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents4 = fileContents4 ? fileContents4 : comparableText4;
+        const result4 = apply.applyMainTabTabLocationPatch(fileContents4);
+        expect(result4).not.toEqual(null);
         expect(result4).toEqual("InspectorFrontendHostInstance), 'panel', true, true, 'network' // code");
     });
 
-    it("applyMainViewPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        const result = apply.applyMainViewPatch("const moreTools = getExtensions();");
-        expect(result).toEqual("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
-    });
+    // it("applyMainViewPatch correctly changes text", async () => {
+    //     const apply = await import("./simpleView");
+    //     const result = apply.applyMainViewPatch("const moreTools = getExtensions();");
+    //     expect(result).toEqual("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
+    // });
 
     it("applySelectTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const result = apply.applySelectTabPatch("selectTab(id, userGesture, forceFocus) { // code");
+
+        const comparableText = "selectTab(id, userGesture, forceFocus) { // code"
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applySelectTabPatch(fileContents);
+        expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
 
-        const result2 = apply.applySelectTabPatch("selectTab(id,userGesture, forceFocus) { // code");
+        const comparableText2 = "selectTab(id,userGesture, forceFocus) { // code";
+        let fileContents2 = getTextFromFile("ui/TabbedPane.js");
+        fileContents2 = fileContents2 ? fileContents2 : comparableText2;
+        const result2 = apply.applySelectTabPatch(fileContents2);
+        expect(result2).not.toEqual(null);
         expect(result2).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
     });
 
     it("applyShowTabElementPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const result = apply.applyShowTabElement("_showTabElement(index, tab) { // code");
+
+        const comparableText = "_showTabElement(index, tab) { // code";
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyShowTabElement(fileContents);
+        expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining("_showTabElement(index, tab) { if ("));
     });
 
     it("applyInspectorCommonCssPatch correctly changes text", async () => {
-        const expectedCss = ":host-context(.platform-mac) .monospace,";
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss);
-        expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
-        expect(result.endsWith(".monospace,")).toEqual(true);
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonCssPatch(fileContents);
+        expect(result).not.toEqual(null);
+        if (result) {
+          expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
+          expect(result.endsWith(".monospace,")).toEqual(true);
+        }
     });
 
     it("applyInspectorCommonCssPatch correctly changes text in release mode", async () => {
-        const expectedCss = ":host-context(.platform-mac) .monospace,";
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss, true);
-        expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
-        expect(result.endsWith(".monospace,")).toEqual(true);
-        expect(result.indexOf("\\n") > -1).toEqual(true);
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonCssPatch(comparableText, true);
+        expect(result).not.toEqual(null);
+        if (result) {
+          expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
+          expect(result.endsWith(".monospace,")).toEqual(true);
+          expect(result.indexOf("\\n") > -1).toEqual(true);
+        }
     });
 });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -27,22 +27,30 @@ export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: b
 }
 
 export function applyCommonRevealerPatch(content: string) {
-    return content.replace(
-        /Common\.Revealer\.reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g,
-        `Common.Revealer.reveal = ${revealInVSCode.toString().slice(0, -1)}`);
+    const pattern = /Common\.Revealer\.reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `Common.Revealer.reveal = ${revealInVSCode.toString().slice(0, -1)}`);
+    } else {
+        return null;
+    }
 }
 
 export function applyInspectorViewPatch(content: string) {
-    return content
-        .replace(
-            /handleAction\(context,\s*actionId\)\s*{/g,
-            "handleAction(context, actionId) { return false;");
+    const pattern = /handleAction\(context,\s*actionId\)\s*{/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, 'handleAction(context, actionId) { return false;');
+    } else {
+        return null;
+    }
 }
 
 export function applyMainViewPatch(content: string) {
-    return content.replace(
-        /const moreTools\s*=\s*[^;]+;/g,
-        "const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
+    const pattern = /const moreTools\s*=\s*[^;]+;/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, 'const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };');
+    } else {
+        return null;
+    }
 }
 
 export function applySelectTabPatch(content: string) {
@@ -72,9 +80,12 @@ export function applySelectTabPatch(content: string) {
         return `id !== '${tab}'`;
     }).join(" && ");
 
-    return content.replace(
-        /selectTab\(id,\s*userGesture,\s*forceFocus\)\s*{/g,
-        `selectTab\(id, userGesture, forceFocus\) { if (${condition}) return false;`);
+    const pattern = /selectTab\(id,\s*userGesture,\s*forceFocus\)\s*{/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `selectTab\(id, userGesture, forceFocus\) { if (${condition}) return false;`);
+    } else {
+        return null;
+    }
 }
 
 export function applyShowTabElement(content: string) {
@@ -104,21 +115,30 @@ export function applyShowTabElement(content: string) {
         return `tab._id !== '${tab}'`;
     }).join(" && ");
 
-    return content.replace(
-        /_showTabElement\(index,\s*tab\)\s*{/g,
-        `_showTabElement\(index, tab\) { if (${condition}) return false;`);
+    const pattern = /_showTabElement\(index,\s*tab\)\s*{/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `_showTabElement\(index, tab\) { if (${condition}) return false;`);
+    } else {
+        return null;
+    }
 }
 
 export function applyDrawerTabLocationPatch(content: string) {
-    return content.replace(
-        /this._showDrawer.bind\s*\(this,\s*false\),\s*'drawer-view',\s*true,\s*true/g,
-        `this._showDrawer.bind\(this, false\), 'drawer-view', true, true, 'network.blocked-urls'`);
+    const pattern = /this._showDrawer.bind\s*\(this,\s*false\),\s*'drawer-view',\s*true,\s*true/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `this._showDrawer.bind\(this, false\), 'drawer-view', true, true, 'network.blocked-urls'`);
+    } else {
+        return null;
+    }
 }
 
 export function applyMainTabTabLocationPatch(content: string) {
-    return content.replace(
-        /InspectorFrontendHostInstance\),\s*'panel',\s*true,\s*true,\s*Root.Runtime.queryParam\('panel'\)/g,
-        `InspectorFrontendHostInstance\), 'panel', true, true, 'network'`);
+    const pattern = /InspectorFrontendHostInstance\),\s*'panel',\s*true,\s*true,\s*Root.Runtime.queryParam\('panel'\)/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `InspectorFrontendHostInstance\), 'panel', true, true, 'network'`);
+    } else {
+        return null;
+    }
 }
 
 export function applyInspectorCommonCssPatch(content: string, isRelease?: boolean) {
@@ -182,17 +202,23 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
         drawerCSS +
         networkCSS;
 
-    let result = content.replace(
-        /(:host-context\(\.platform-mac\)\s*\.monospace,)/g,
-        `${addCSS}${separator} $1`);
+    let result;
+    const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g
+    if (content.match(pattern)) {
+        result = content.replace(pattern, `${addCSS}${separator} $1`);
+    } else {
+        return null;
+    }
 
     const replaceFocusTabSlider =
         `.tabbed-pane-tab-slider .enabled {
             display: none !important;
         }`.replace(/\n/g, separator);
 
-    result = result.replace(
-        /(\.tabbed-pane-tab-slider\s*\.enabled\s*\{([^\}]*)?\})/g,
-        replaceFocusTabSlider);
-    return result;
+    const tabbedPanePattern = /(\.tabbed-pane-tab-slider\s*\.enabled\s*\{([^\}]*)?\})/g;
+    if (result.match(tabbedPanePattern)) {
+        return result.replace(tabbedPanePattern, replaceFocusTabSlider);
+    } else {
+        return null;
+    }
 }

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -1,58 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import ToolsHost from "../toolsHost";
-
-declare var InspectorFrontendHost: ToolsHost;
-
-interface IRevealable {
-    lineNumber: number;
-    columnNumber: number;
-    uiSourceCode: {
-        _url: string;
-    };
-}
-
-export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: boolean) {
-    if (revealable && revealable.uiSourceCode && revealable.uiSourceCode._url) {
-        InspectorFrontendHost.openInEditor(
-            revealable.uiSourceCode._url,
-            revealable.lineNumber,
-            revealable.columnNumber,
-            omitFocus,
-        );
-    }
-
-    return Promise.resolve();
-}
-
-export function applyCommonRevealerPatch(content: string) {
-    const pattern = /Common\.Revealer\.reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g;
-    if (content.match(pattern)) {
-        return content.replace(pattern, `Common.Revealer.reveal = ${revealInVSCode.toString().slice(0, -1)}`);
-    } else {
-        return null;
-    }
-}
-
-export function applyInspectorViewPatch(content: string) {
-    const pattern = /handleAction\(context,\s*actionId\)\s*{/g;
-    if (content.match(pattern)) {
-        return content.replace(pattern, 'handleAction(context, actionId) { return false;');
-    } else {
-        return null;
-    }
-}
-
-export function applyMainViewPatch(content: string) {
-    const pattern = /const moreTools\s*=\s*[^;]+;/g;
-    if (content.match(pattern)) {
-        return content.replace(pattern, 'const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };');
-    } else {
-        return null;
-    }
-}
-
 export function applySelectTabPatch(content: string) {
     const networkTabs = [
         "network",

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Allow unused variables in the mocks to have leading underscore
-// tslint:disable: variable-name
-
+import fs from "fs";
 import { ExtensionContext } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
+
+// Allow unused variables in the mocks to have leading underscore
+// tslint:disable: variable-name
 
 export type Mocked<T> = {
     -readonly [P in keyof T]:
@@ -127,4 +128,19 @@ export function getFirstCallback(mock: jest.Mock, callbackArgIndex: number = 0):
     // tslint:disable-next-line: ban-types
     { callback: Function, thisObj: object } {
     return { callback: mock.mock.calls[0][callbackArgIndex], thisObj: mock.mock.instances[0] };
+}
+
+/**
+ * Returns the contents of the specified file, if the file is not found returns null
+ * @param uri The uri relative to the 'gen' folder specified in EDGE_CHROMIUM_PATH environment variable.
+ */
+export function getTextFromFile(uri: string) {
+  const toolsGenDir =
+      `${process.env.EDGE_CHROMIUM_PATH}/out/${process.env.EDGE_CHROMIUM_OUT_DIR}/gen/devtools/`;
+  const filePath = `${toolsGenDir}${uri}`;
+  if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath, "utf8");
+  }
+
+  return null;
 }


### PR DESCRIPTION
Network extension version of https://github.com/microsoft/vscode-edge-devtools/pull/123

**Description:**
This PR does a medium size refactoring on simpleView polyfill that I consider need to expand to the rest of polyfills:

SimpleView.test.ts
Currently the tests verify that a function can be override by the polyfills. The issue is that the actual content of the file constantly changes. This PR forks the behavior as follows:
If run in the server: It will continue working as today, verifying that a static text can be patched.
If run locally: it will verify if the actual files exist in disk, if they do it will run the tests again the file contents, and it will fail if the contents do not match. This will make patching and spotting differences easier by reducing turnaround time.

Also removes unused code in SimpleView.ts and SimpleView.test.ts

PostBuild.ts:
Currently "Release" and "Debug" mode are treated as one, this creates issues as the files on DevTools side tend to be moved or refactored, this makes the patching process a manual one. This PR splits the logic between Release and Debug, so if a release file that is needed to be patched is not present it will now throw an error.

launch.json
As part of the change in postbuild.ts, the user can now indicate if they are running a "Release" version (following Contributing.md instructions or if they are doing a development version (full chromium repo)

The rest of the changes are to support the scenarios mentioned above.
